### PR TITLE
feat(status model): do not filter out unhydrated statuses

### DIFF
--- a/src/components/Columns.svelte
+++ b/src/components/Columns.svelte
@@ -49,14 +49,14 @@
       <Chip
         backgroundColor={status.backgroundColor}
         color={status.color}
-        label={status.label} />
+        label={status.label || status.id} />
       <Count
         total={status.contentItems.page.totalElements}
         additionalInfo={status.hasDateLast7DaysFacet ? '(from last 7 days)' : ''}
         count={status.contentItems.page.elementsInCurrentPage} />
       <div
         class="content-item-wrap"
-        use:dndzone={{ items: status.contentItems.items, type: 'content-items', dropTargetStyle: { outline: 'none' } }}
+        use:dndzone={{ items: status.contentItems.items, type: 'content-items', dropTargetStyle: { outline: 'none' }, dropFromOthersDisabled: !status.hydrated }}
         on:consider={(e) => handleConsider(status.id, e)}
         on:finalize={(e) => handleFinalize(status.id, e)}>
         {#each status.contentItems.items as contentItem (contentItem.id)}

--- a/src/services/data/content-items.ts
+++ b/src/services/data/content-items.ts
@@ -36,6 +36,9 @@ export async function fetchForStatus(
   params: Record<string, any>
 ): Promise<ContentItemCollection> {
   try {
+    if (!status.hydrated) {
+      return status.contentItems;
+    }
     const { dcClient, hubId, folderId, contentRepositoryId } = client;
     const { data } = await dcClient.post(
       `/hubs/${hubId}/content-items/facet`,

--- a/src/services/data/workflow-states.ts
+++ b/src/services/data/workflow-states.ts
@@ -13,15 +13,13 @@ export async function fetchAndHydrate(
   params: Record<string, any> = { size: 100 }
 ): Promise<Status[]> {
   const { data } = await dcClient.get(`/hubs/${hubId}/workflow-states`, params);
-  const hydratedStatuses = statuses
-    .map(({ id }: InstallationParamsStatus) => {
-      const foundStatus = (data as any)?._embedded['workflow-states'].find(
-        (status: any) => status.id === id
-      );
+  const hydratedStatuses = statuses.map(({ id }: InstallationParamsStatus) => {
+    const foundStatus = (data as any)?._embedded['workflow-states'].find(
+      (status: any) => status.id === id
+    );
 
-      return new Status(foundStatus || { id });
-    })
-    .filter((status: Status) => status.hydrated);
+    return new Status(foundStatus || { id });
+  });
 
   const lastStatus = getLastStatus(hydratedStatuses);
   if (lastStatus) {
@@ -53,7 +51,5 @@ export async function fetchAndHydrateWithContentItems(
 }
 
 export function getContentItemsCount(statuses: Status[]): number {
-  return statuses.reduce((p, c) => {
-    return p + c.contentItems.items.length;
-  }, 0);
+  return statuses.reduce((p, c) => p + c.contentItems.items.length, 0);
 }

--- a/src/services/models/status.ts
+++ b/src/services/models/status.ts
@@ -52,22 +52,21 @@ export default class Status {
   public backgroundColor?: string;
   public facets?: FacetField[];
   private appliedFacets: string[] = [];
-  public contentItems!: ContentItemCollection;
+  public contentItems: ContentItemCollection;
   constructor({ id, label, color }: any = {}) {
     this.id = id;
-    this.contentItems = {
-      items: [],
-      page: {},
-      statusId: this.id,
-    };
-    if (label && color) {
+    this.contentItems = getContentItemsPlaceholder(id);
+    const hasStatus = label;
+    if (hasStatus) {
       this.hydrated = true;
       this.label = label;
-      this.backgroundColor = color;
       this.color = PRESETS[color] || getContrastType(color);
+      this.backgroundColor = color;
       this.facets = [];
       this.addStatusFacetField(this.id);
       this.appliedFacets = [];
+    } else {
+      this.color = DARK;
     }
   }
 
@@ -100,10 +99,24 @@ export default class Status {
   }
 }
 
+function getContentItemsPlaceholder(id: string) {
+  return {
+    items: [],
+    page: {
+      size: 20,
+      totalElements: 0,
+      totalPages: 0,
+      number: 0,
+      elementsInCurrentPage: 0,
+    },
+    statusId: id,
+  };
+}
+
 function getContrastType(rgb: string) {
   const match = rgb.match(/rgb\((\d{1,3}),(\d{1,3}),(\d{1,3})\)/);
   if (!match) {
-    return DARK;
+    return;
   }
   match.shift();
   return getLuminance(match) > 0.179 ? DARK : LIGHT;


### PR DESCRIPTION
Previously statuses that were not found on the hub were filtered out which does not match the AC of "If a status is not found it should still be shown". Now these unmapped statuses are shown and dragging to the column should be disabled