### PR TITLE
fix(card): displaying assigned user avatar to the right

### DIFF
--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -58,6 +58,16 @@
     .subtitle {
       overflow-wrap: break-word;
     }
+    .header {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      margin-bottom: 20px;
+    }
+    .title {
+      display: flex;
+      flex-direction: column;
+    }
     .subtitle,
     .footer {
       font-size: 0.9em;
@@ -73,13 +83,17 @@
   on:dblclick={() => {
     $extensionClient.dashboardSdk.applicationNavigator.openContentItem(contentItem);
   }}>
-  <a href={target} target="_top">
-    <h1 class="title">{contentItem.label}</h1>
-  </a>
   <div>
-    <span
-      class="subtitle">{contentTypeLookup[contentItem.schema]?.settings?.label}</span>
-    <Assignees users={getAssignedUsers()} />
+    <div class="header">
+      <div class="titles">
+        <a href={target} target="_top">
+          <h1 class="title">{contentItem.label}</h1>
+        </a>
+        <span
+          class="subtitle">{contentTypeLookup[contentItem.schema]?.settings?.label}</span>
+      </div>
+      <Assignees users={getAssignedUsers()} />
+    </div>
     <footer class="footer">
       Last changed
       {formatDate(contentItem.lastModifiedDate)}

--- a/src/components/__snapshots__/Card.spec.ts.snap
+++ b/src/components/__snapshots__/Card.spec.ts.snap
@@ -3,36 +3,44 @@
 exports[`card component should render a card component 1`] = `
 <div>
   <section
-    class="card svelte-aw75r8"
+    class="card svelte-1mso38a"
     data-testid="card"
   >
-    <a
-      class="svelte-aw75r8"
-      target="_top"
-    >
-      <h1
-        class="title svelte-aw75r8"
-      >
-        LABEL
-      </h1>
-    </a>
-     
     <div
-      class="svelte-aw75r8"
+      class="svelte-1mso38a"
     >
-      <span
-        class="subtitle svelte-aw75r8"
-      >
-        SCHEMA LABEL
-      </span>
-       
       <div
-        class="assignees svelte-1ilxe5k"
-        title=""
-      />
+        class="header svelte-1mso38a"
+      >
+        <div
+          class="titles svelte-1mso38a"
+        >
+          <a
+            class="svelte-1mso38a"
+            target="_top"
+          >
+            <h1
+              class="title svelte-1mso38a"
+            >
+              LABEL
+            </h1>
+          </a>
+           
+          <span
+            class="subtitle svelte-1mso38a"
+          >
+            SCHEMA LABEL
+          </span>
+        </div>
+         
+        <div
+          class="assignees svelte-1ilxe5k"
+          title=""
+        />
+      </div>
        
       <footer
-        class="footer svelte-aw75r8"
+        class="footer svelte-1mso38a"
       >
         Last changed
       


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfils the following requirements:

- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Assigned user avatar was underneath the card title and subtitle

## What is the new behavior?

- Assigned user avatar is now in the top right corner of the card

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR -->
