### PR TITLE
fix(asignee filter): changing alignment of the filter icon

### DIFF
--- a/src/components/AssigneeFilter.svelte
+++ b/src/components/AssigneeFilter.svelte
@@ -80,6 +80,10 @@
     flex-direction: row;
   }
 
+  .filter-icon.has-assignees :global(svg path) {
+    fill: #039be5;
+  }
+
   .modal-popup {
     padding: 10px 16px;
     background-color: #fff;
@@ -119,6 +123,12 @@
 {/if}
 <section bind:this={sectionElement}>
   <div class="assignee-filter">
+    <div
+      class="filter-icon {assignees.length ? 'has-assignees' : ''}"
+      data-testid="filter-icon"
+      on:click={showModal}>
+      <Icon icon={FilterIcon} width="20px" height="20px" />
+    </div>
     <span on:click={showModal}>Assignee</span>
     <div class="assignee-names">
       {#if assignees.length < 1}
@@ -133,9 +143,6 @@
             clickable={true} />
         {/each}
       {/if}
-    </div>
-    <div class="filter-icon" data-testid="filter-icon" on:click={showModal}>
-      <Icon icon={FilterIcon} width="20px" height="20px" />
     </div>
   </div>
   {#if isModalVisible}

--- a/src/components/__snapshots__/AssigneeFilter.spec.ts.snap
+++ b/src/components/__snapshots__/AssigneeFilter.spec.ts.snap
@@ -4,19 +4,33 @@ exports[`AssigneeFilter should render the assignee filter 1`] = `
 <div>
    
   <section
-    class="svelte-6yrjka"
+    class="svelte-1ggh271"
   >
     <div
-      class="assignee-filter svelte-6yrjka"
+      class="assignee-filter svelte-1ggh271"
     >
+      <div
+        class="filter-icon  svelte-1ggh271"
+        data-testid="filter-icon"
+      >
+        <div
+          class=" svelte-zpbvvv"
+          style="--icon-width: 20px; --icon-height: 20px;"
+        >
+          <object
+            src="ic-filter.svg/"
+          />
+        </div>
+      </div>
+       
       <span
-        class="svelte-6yrjka"
+        class="svelte-1ggh271"
       >
         Assignee
       </span>
        
       <div
-        class="assignee-names svelte-6yrjka"
+        class="assignee-names svelte-1ggh271"
       >
         <div
           class=" clickable  svelte-h28tab"
@@ -30,9 +44,23 @@ exports[`AssigneeFilter should render the assignee filter 1`] = `
            
         </div>
       </div>
-       
+    </div>
+     
+  </section>
+</div>
+`;
+
+exports[`AssigneeFilter should render the assignee filter with selected assignees 1`] = `
+<div>
+   
+  <section
+    class="svelte-1ggh271"
+  >
+    <div
+      class="assignee-filter svelte-1ggh271"
+    >
       <div
-        class="filter-icon svelte-6yrjka"
+        class="filter-icon has-assignees svelte-1ggh271"
         data-testid="filter-icon"
       >
         <div
@@ -44,29 +72,15 @@ exports[`AssigneeFilter should render the assignee filter 1`] = `
           />
         </div>
       </div>
-    </div>
-     
-  </section>
-</div>
-`;
-
-exports[`AssigneeFilter should render the assignee filter with selected assignees 1`] = `
-<div>
-   
-  <section
-    class="svelte-6yrjka"
-  >
-    <div
-      class="assignee-filter svelte-6yrjka"
-    >
+       
       <span
-        class="svelte-6yrjka"
+        class="svelte-1ggh271"
       >
         Assignee
       </span>
        
       <div
-        class="assignee-names svelte-6yrjka"
+        class="assignee-names svelte-1ggh271"
       >
         <div
           class=" clickable removeable svelte-h28tab"
@@ -118,20 +132,6 @@ exports[`AssigneeFilter should render the assignee filter with selected assignee
         </div>
         
       </div>
-       
-      <div
-        class="filter-icon svelte-6yrjka"
-        data-testid="filter-icon"
-      >
-        <div
-          class=" svelte-zpbvvv"
-          style="--icon-width: 20px; --icon-height: 20px;"
-        >
-          <object
-            src="ic-filter.svg/"
-          />
-        </div>
-      </div>
     </div>
      
   </section>
@@ -147,19 +147,33 @@ exports[`AssigneeFilter should render the modal with a list of users 1`] = `
   />
    
   <section
-    class="svelte-6yrjka"
+    class="svelte-1ggh271"
   >
     <div
-      class="assignee-filter svelte-6yrjka"
+      class="assignee-filter svelte-1ggh271"
     >
+      <div
+        class="filter-icon  svelte-1ggh271"
+        data-testid="filter-icon"
+      >
+        <div
+          class=" svelte-zpbvvv"
+          style="--icon-width: 20px; --icon-height: 20px;"
+        >
+          <object
+            src="ic-filter.svg/"
+          />
+        </div>
+      </div>
+       
       <span
-        class="svelte-6yrjka"
+        class="svelte-1ggh271"
       >
         Assignee
       </span>
        
       <div
-        class="assignee-names svelte-6yrjka"
+        class="assignee-names svelte-1ggh271"
       >
         <div
           class=" clickable  svelte-h28tab"
@@ -173,28 +187,14 @@ exports[`AssigneeFilter should render the modal with a list of users 1`] = `
            
         </div>
       </div>
-       
-      <div
-        class="filter-icon svelte-6yrjka"
-        data-testid="filter-icon"
-      >
-        <div
-          class=" svelte-zpbvvv"
-          style="--icon-width: 20px; --icon-height: 20px;"
-        >
-          <object
-            src="ic-filter.svg/"
-          />
-        </div>
-      </div>
     </div>
      
     <div
-      class="modal-popup svelte-6yrjka"
+      class="modal-popup svelte-1ggh271"
       style="top: NaNpx;left: undefinedpx"
     >
       <h3
-        class="svelte-6yrjka"
+        class="svelte-1ggh271"
       >
         Assignee
       </h3>
@@ -358,19 +358,33 @@ exports[`AssigneeFilter should render the modal with a list of users with checkb
   />
    
   <section
-    class="svelte-6yrjka"
+    class="svelte-1ggh271"
   >
     <div
-      class="assignee-filter svelte-6yrjka"
+      class="assignee-filter svelte-1ggh271"
     >
+      <div
+        class="filter-icon has-assignees svelte-1ggh271"
+        data-testid="filter-icon"
+      >
+        <div
+          class=" svelte-zpbvvv"
+          style="--icon-width: 20px; --icon-height: 20px;"
+        >
+          <object
+            src="ic-filter.svg/"
+          />
+        </div>
+      </div>
+       
       <span
-        class="svelte-6yrjka"
+        class="svelte-1ggh271"
       >
         Assignee
       </span>
        
       <div
-        class="assignee-names svelte-6yrjka"
+        class="assignee-names svelte-1ggh271"
       >
         <div
           class=" clickable removeable svelte-h28tab"
@@ -422,28 +436,14 @@ exports[`AssigneeFilter should render the modal with a list of users with checkb
         </div>
         
       </div>
-       
-      <div
-        class="filter-icon svelte-6yrjka"
-        data-testid="filter-icon"
-      >
-        <div
-          class=" svelte-zpbvvv"
-          style="--icon-width: 20px; --icon-height: 20px;"
-        >
-          <object
-            src="ic-filter.svg/"
-          />
-        </div>
-      </div>
     </div>
      
     <div
-      class="modal-popup svelte-6yrjka"
+      class="modal-popup svelte-1ggh271"
       style="top: NaNpx;left: undefinedpx"
     >
       <h3
-        class="svelte-6yrjka"
+        class="svelte-1ggh271"
       >
         Assignee
       </h3>

--- a/src/components/__snapshots__/Toolbar.spec.ts.snap
+++ b/src/components/__snapshots__/Toolbar.spec.ts.snap
@@ -24,19 +24,33 @@ exports[`toolbar component should render a toolbar component 1`] = `
        
        
       <section
-        class="svelte-6yrjka"
+        class="svelte-1ggh271"
       >
         <div
-          class="assignee-filter svelte-6yrjka"
+          class="assignee-filter svelte-1ggh271"
         >
+          <div
+            class="filter-icon  svelte-1ggh271"
+            data-testid="filter-icon"
+          >
+            <div
+              class=" svelte-zpbvvv"
+              style="--icon-width: 20px; --icon-height: 20px;"
+            >
+              <object
+                src="ic-filter.svg/"
+              />
+            </div>
+          </div>
+           
           <span
-            class="svelte-6yrjka"
+            class="svelte-1ggh271"
           >
             Assignee
           </span>
            
           <div
-            class="assignee-names svelte-6yrjka"
+            class="assignee-names svelte-1ggh271"
           >
             <div
               class=" clickable  svelte-h28tab"
@@ -48,20 +62,6 @@ exports[`toolbar component should render a toolbar component 1`] = `
                 All
               </span>
                
-            </div>
-          </div>
-           
-          <div
-            class="filter-icon svelte-6yrjka"
-            data-testid="filter-icon"
-          >
-            <div
-              class=" svelte-zpbvvv"
-              style="--icon-width: 20px; --icon-height: 20px;"
-            >
-              <object
-                src="ic-filter.svg/"
-              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfils the following requirements:

- [x] Tests (`npm run test`) for the changes have been added (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The assignees filter icons is on the right of the assignees chips

## What is the new behavior?

The assignees filter icon has been moved to the right of the assignees chips to be consistent with other dashboards

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

